### PR TITLE
Haga/layouts

### DIFF
--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -45,7 +45,7 @@
   	  <td></td>
   	  <td>
   	    <%= link_to "編集する", edit_admin_customer_path, class: "btn btn-success mr-5" %>
-  	    <%= link_to "注文履歴一覧", admin_order_path,class: 'btn btn-primary' %>
+  	    <%= link_to "注文履歴一覧", admin_path,class: 'btn btn-primary' %>
   	  </td>
     </tr>
   </table>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -34,7 +34,7 @@
   	  <td>会員ステータス</td>
   	  <td>
   	    <% if @customer.is_deleted == false %>
-          有効
+          <span class="text-success">有効</span>
         <% elsif %>
           退会
         <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,12 @@
 <header class="border-bottom">
   <nav class="navbar navbar-expand-lg navbar-light">
     <div class="container">
-      <a class="col navbar-brand" href="/"><span>ながのCAKE</span></a>
+      <% if admin_signed_in? %>
+        <a class="col navbar-brand" href="/admin"><span>ながのCAKE</span></a>
+      <% else %>
+        <a class="col navbar-brand" href="/"><span>ながのCAKE</span></a>
+      <% end %>
+
       <% if customer_signed_in? %>
         <p class="col mb-0">ようこそ<%= current_customer.last_name %>さん</p>
       <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,8 +23,8 @@
           <li>
             <%= link_to "ログアウト", destroy_customer_session_path,method: :delete,class: 'nav-link text-dark border rounded rounded-3' %>
           </li>
-          
-        <% elsif admin_signed_in? %>  
+
+        <% elsif admin_signed_in? %>
           <li>
             <%= link_to "商品一覧", admin_items_path,class: 'nav-link text-dark border rounded rounded-3 mr-5' %>
           </li>
@@ -37,11 +37,11 @@
           </li>
           <li>
             <%= link_to "ジャンル一覧", admin_genres_path,class: 'nav-link text-dark border rounded rounded-3 mr-5' %>
-          </li>          
+          </li>
           <li>
             <%= link_to "ログアウト", destroy_admin_session_path,method: :delete,class: 'nav-link text-dark border rounded rounded-3' %>
-          </li>          
-          
+          </li>
+
         <% else %>
           <li>
             <%= link_to "About",  about_path,class: 'nav-link text-dark border rounded rounded-3 mr-5' %>


### PR DESCRIPTION
管理者ログイン時のロゴの遷移先変更
顧客詳細ページのボタンの遷移先(注文履歴一覧へ)